### PR TITLE
Use thing-at-point for lazy loading

### DIFF
--- a/js-doc.el
+++ b/js-doc.el
@@ -406,7 +406,7 @@ The comment style can be custimized via `customize-group js-doc'"
   "Describe the JsDoc tag"
   (interactive)
   (let ((tag (completing-read "Tag: " (js-doc-make-tag-list)
-			      nil t (word-at-point) nil nil))
+			      nil t (thing-at-point 'word) nil nil))
 	(temp-buffer-show-hook #'(lambda ()
 				  (fill-region 0 (buffer-size))
 				  (fit-window-to-buffer))))


### PR DESCRIPTION
word-at-point is not an autoloaded function, so it is necessary to load thingatpt.el
for using it. While thing-at-point is an autoloaded function.