### PR TITLE
explicitly separate param from its description

### DIFF
--- a/js-doc.el
+++ b/js-doc.el
@@ -207,7 +207,7 @@ Format will be replaced its value in `js-doc-format-string'")
 
 ;; formats for function-doc
 
-(defcustom js-doc-parameter-line " * @param {} %p\n"
+(defcustom js-doc-parameter-line " * @param {} %p - \n"
   "parameter line.
  %p will be replaced with the parameter name."
   :group 'js-doc)


### PR DESCRIPTION
This makes things much more readable for more complex params as [shown in the docs](http://usejsdoc.org/tags-param.html).