### PR TITLE
implement js-doc-insert-function-doc-snippet

### DIFF
--- a/js-doc.el
+++ b/js-doc.el
@@ -301,7 +301,9 @@ js-doc regards current state as in JsDoc style comment"
           (split-string (buffer-substring-no-properties from to) ",")))
 
 (defun js-doc--function-doc-metadata ()
-  "Parse the function's metadata for use with JsDoc."
+  "Parse the function's metadata for use with JsDoc.
+The point should be at the beginning of the function,
+which is accomplished with js-doc--beginning-of-defun."
   (interactive)
   ;; Parse function info
   (let ((metadata '())
@@ -311,8 +313,6 @@ js-doc regards current state as in JsDoc style comment"
         begin
         end)
     (save-excursion
-      (js-doc--beginning-of-defun)
-
       (setq from (search-forward "(" nil t)
             to (1- (search-forward ")" nil t)))
 
@@ -364,8 +364,6 @@ The comment style can be custimized via `customize-group js-doc'"
     (add-to-list 'document-list
 		 (js-doc-format-string js-doc-bottom-line) t)
     ;; Insert the document
-    (search-backward "(" nil t)
-    (beginning-of-line)
     (setq from (point))                 ; for indentation
 
     ;; put document string into document-list
@@ -389,12 +387,10 @@ The comment style can be custimized via `customize-group js-doc'"
   (interactive)
 
   (with-eval-after-load 'yasnippet
+    (js-doc--beginning-of-defun)
+
     (let ((metadata (js-doc--function-doc-metadata))
           (field-count 1))
-      (js-doc--beginning-of-defun)
-      (search-backward "(" nil t)
-      (beginning-of-line)
-
       (yas-expand-snippet
        (concat
         js-doc-top-line


### PR DESCRIPTION
This introduces `js-doc-insert-function-doc-snippet`.

This uses yasnippet (if it's available) to insert the jsdoc comment which enables the use of placeholder values and cycling through the various fields.

To enable this, common functionality has been factored out to separate functions, most notably `js-doc--function-doc-metadata` which parses the function metadata into an alist which is then used by the jsdoc insertion functions.

You can see the advantages of the new `M-x js-doc-insert-function-doc-snippet` with this recording:

[![recording](https://i.imgur.com/333SwwC.gif)](https://i.imgur.com/333SwwC.gifv)

While I was at it I changed the regular `js-doc-insert-function-doc` to save the position of the jsdoc description line so that the point/cursor is moved to it after the jsdoc is inserted (see #13).

This supersedes #14.
