### PR TITLE
Remove unused dependency on deprecated iswitchb

### DIFF
--- a/js-doc.el
+++ b/js-doc.el
@@ -47,8 +47,6 @@
 
 ;;; Code:
 
-(require 'iswitchb)
-
 ;;; Custom:
 (defgroup js-doc nil
   "Insert JsDoc style comment easily."
@@ -415,13 +413,6 @@ The comment style can be custimized via `customize-group js-doc'"
            (incf field-count)
            (incf field-count)))
         js-doc-bottom-line)))))
-
-;; http://www.emacswiki.org/emacs/UseIswitchBuffer
-(defun js-doc-icompleting-read (prompt collection)
-  (let ((iswitchb-make-buflist-hook
-	 #'(lambda ()
-             (setq iswitchb-temp-buflist collection))))
-    (iswitchb-read-buffer prompt nil nil)))
 
 (defun js-doc-make-tag-list ()
   (let ((taglist '()))


### PR DESCRIPTION
Fixes #18. (I even forgot that I had already made a fork and made this change.)

`js-doc-icompleting-read` isn't used anywhere else in this package, and since it's a library-ish function being exported from a non-library package it's also very unlikely that someone out there has a dependency on this function.